### PR TITLE
Fixed bug of tokenizer_kwargs in AutoDANManager in autoda.py.

### DIFF
--- a/aisafetylab/attack/attackers/autodan.py
+++ b/aisafetylab/attack/attackers/autodan.py
@@ -338,7 +338,7 @@ class AutoDANManager(BaseAttackManager):
             .eval()
             .to(device)
         )
-        if tokenizer_kwargs:
+        if tokenizer_kwargs is None:
             tokenizer = AutoTokenizer.from_pretrained(target_model_name_or_path)
         else:
             tokenizer = AutoTokenizer.from_pretrained(target_model_name_or_path, **tokenizer_kwargs)


### PR DESCRIPTION
The if-else about tokenizer_kwargs is wrong. Based on L342 and L344, the if statement should be "if tokenizer_kwargs is None".